### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -7,6 +7,3 @@ docker:
   - name: ansible-role-visual-studio-code-01
     image: ubuntu
     image_version: '16.04'
-
-testinfra:
-  hosts: ansible-role-visual-studio-code-01

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,2 +1,7 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_visual_studio_code(Command):
     assert Command('which code').rc == 0


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.