### PR TITLE
Workaround for Ansible dependency issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ install:
   - pip install "ansible~=$ANSIBLE_VERSION"
 
   # Install Python API for Docker (required by Molecule Docker driver)
-  - pip install docker
+  # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
+  - pip install 'docker<3.0'
 
   # Install Molecule
   - pip install 'molecule==2.5'


### PR DESCRIPTION
Ansible is incompatible with version 3.0.0 of the Python Docker library (see https://github.com/ansible/ansible/issues/35612).