### PR TITLE
Fixed default group for users

### DIFF
--- a/tasks/install-extensions.yml
+++ b/tasks/install-extensions.yml
@@ -12,11 +12,10 @@
 
 - name: create config directories for users
   become: yes
+  become_user: "{{ item.0.username }}"
   file:
     path: "~{{ item.0.username }}/.config"
     state: directory
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.username }}"
     mode: 'u=rwx,go=r'
   with_subelements:
     - "{{ users }}"
@@ -25,11 +24,10 @@
 
 - name: create Visual Studio Code directories for users
   become: yes
+  become_user: "{{ item.0.username }}"
   file:
     path: "~{{ item.0.username }}/.config/Code/User"
     state: directory
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.username }}"
     mode: 'u=rwx,go='
   with_subelements:
     - "{{ users }}"

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -1,22 +1,20 @@
 ---
 - name: create settings directory
   become: yes
+  become_user: "{{ item.username }}"
   file:
     path: '~{{ item.username }}/.config/Code/User'
     state: directory
-    owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
 
 - name: write settings
   become: yes
+  become_user: "{{ item.username }}"
   template:
     src: settings.json.j2
     dest: '~{{ item.username }}/.config/Code/User/settings.json'
     force: no
-    owner: '{{ item.username }}'
-    group: '{{ item.username }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   when: "item.visual_studio_code_settings is defined and item.visual_studio_code_settings not in ({}, '', None, omit)"


### PR DESCRIPTION
Hard coding the group to be the same as the username usually works for Ubuntu, but some distributions have a common default group (e.g. `users`) instead.

Bug fix: resolves #101