### PR TITLE
Fixed duplicate APT repository

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -18,6 +18,7 @@
   become: yes
   apt_repository:
     repo: deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main
+    filename: vscode
     state: present
 
 - name: install VS Code (apt)


### PR DESCRIPTION
The default name generated by Ansible didn't match the name used by VS Code itself.

Fix: resolves #113