### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to install the [Visual Studio Code](https://code.visualstudio.com) IDE / te
 Requirements
 ------------
 
-* Ansible >= 2.4 (earlier versions may work but are not tested)
+* Ansible >= 2.4
 
 * Linux Distribution
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,14 +4,5 @@
     that:
       - "ansible_pkg_mgr in ('apt', 'yum', 'dnf', 'zypper')"
 
-- include: install-apt.yml
-  when: ansible_pkg_mgr == 'apt'
-
-- include: install-yum.yml
-  when: ansible_pkg_mgr == 'yum'
-
-- include: install-dnf.yml
-  when: ansible_pkg_mgr == 'dnf'
-
-- include: install-zypper.yml
-  when: ansible_pkg_mgr == 'zypper'
+- name: 'install ({{ ansible_pkg_mgr }})'
+  include_tasks: 'install-{{ ansible_pkg_mgr }}.yml'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: install.yml
+- import_tasks: install.yml
 
-- include: install-extensions.yml
+- import_tasks: install-extensions.yml
 
-- include: write-settings.yml
+- import_tasks: write-settings.yml


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```