### PR TITLE
Dropped support for Ubuntu Wily

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
-        - wily
         - xenial
     - name: Fedora
       versions:


### PR DESCRIPTION
Canonical ended support for Wily sometime ago.