### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
     - name: Fedora
       versions:


### PR DESCRIPTION
It's not documented as supported in the `README.md`, the install is failing and it's nearing it's end of life anyway.