### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_install.py
+++ b/molecule/default/tests/test_install.py
@@ -6,5 +6,5 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_visual_studio_code(Command):
-    assert Command('which code').rc == 0
+def test_visual_studio_code(host):
+    assert host.run('which code').rc == 0

--- a/molecule/default/tests/test_install_extensions.py
+++ b/molecule/default/tests/test_install_extensions.py
@@ -11,7 +11,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'ms-python.python',
     'wholroyd.jinja'
 ])
-def test_visual_studio_code(Command, extension):
-    output = Command.check_output('sudo --user test_usr -H code %s %s',
-                                  '--install-extension', extension)
+def test_visual_studio_code(host, extension):
+    output = host.check_output('sudo --user test_usr -H code %s %s',
+                               '--install-extension', extension)
     assert 'already installed' in output

--- a/molecule/default/tests/test_settings.py
+++ b/molecule/default/tests/test_settings.py
@@ -6,8 +6,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_settings(File):
-    settings_file = File('/home/test_usr/.config/Code/User/settings.json')
+def test_settings(host):
+    settings_file = host.file('/home/test_usr/.config/Code/User/settings.json')
 
     assert settings_file.exists
     assert settings_file.is_file

--- a/molecule/opensuse/tests/test_install.py
+++ b/molecule/opensuse/tests/test_install.py
@@ -6,5 +6,5 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_visual_studio_code(Command):
-    assert Command('which code').rc == 0
+def test_visual_studio_code(host):
+    assert host.run('which code').rc == 0

--- a/molecule/opensuse/tests/test_install_extensions.py
+++ b/molecule/opensuse/tests/test_install_extensions.py
@@ -11,7 +11,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'ms-python.python',
     'wholroyd.jinja'
 ])
-def test_visual_studio_code(Command, extension):
-    output = Command.check_output('sudo --user test_usr -H code %s %s',
-                                  '--install-extension', extension)
+def test_visual_studio_code(host, extension):
+    output = host.check_output('sudo --user test_usr -H code %s %s',
+                               '--install-extension', extension)
     assert 'already installed' in output

--- a/molecule/opensuse/tests/test_settings.py
+++ b/molecule/opensuse/tests/test_settings.py
@@ -6,8 +6,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_settings(File):
-    settings_file = File('/home/test_usr/.config/Code/User/settings.json')
+def test_settings(host):
+    settings_file = host.file('/home/test_usr/.config/Code/User/settings.json')
 
     assert settings_file.exists
     assert settings_file.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.