### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -2,11 +2,10 @@
 - name: install dependencies (apt)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - ca-certificates
+      - apt-transport-https
     state: present
-  with_items:
-    - ca-certificates
-    - apt-transport-https
 
 - name: install key (apt)
   become: yes

--- a/tasks/install-extensions.yml
+++ b/tasks/install-extensions.yml
@@ -2,13 +2,12 @@
 - name: install extension cli dependencies (apt)
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - gconf2
+      - libasound2
+      - libgtk2.0-0
+      - libxss1
     state: present
-  with_items:
-    - gconf2
-    - libasound2
-    - libgtk2.0-0
-    - libxss1
   when: ansible_pkg_mgr == 'apt'
 
 - name: install extension cli dependencies (dnf)


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'ca-certificates', u
'apt-transport-https']` and remove the loop. This feature will be removed in
version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'gconf2', u'libasound2',
 u'libgtk2.0-0', u'libxss1']` and remove the loop. This feature will be removed
 in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```