### PR TITLE
macOS implementation

### DIFF
--- a/tasks/install-homebrew.yml
+++ b/tasks/install-homebrew.yml
@@ -1,0 +1,5 @@
+---
+- name: install VS Code (brew-cask)
+  homebrew_cask:
+    name: visual-studio-code
+    state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 - name: assert supported distribution
   assert:
     that:
-      - "ansible_pkg_mgr in ('apt', 'yum', 'dnf', 'zypper')"
+      - "ansible_pkg_mgr in ('apt', 'yum', 'dnf', 'zypper', 'homebrew')"
 
 - name: 'install ({{ ansible_pkg_mgr }})'
   include_tasks: 'install-{{ ansible_pkg_mgr }}.yml'

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -3,7 +3,7 @@
   become: yes
   become_user: '{{ item.0.username }}'
   file:
-    path: '~{{ item.0.username }}/.config'
+    path: '~{{ item.0.username }}/{{ config_path }}'
     state: directory
     mode: 'u=rwx,go=r'
   with_subelements:
@@ -15,7 +15,7 @@
   become: yes
   become_user: '{{ item.username }}'
   file:
-    path: '~{{ item.username }}/.config/Code/User'
+    path: '~{{ item.username }}/{{ vscode_config_path }}/User'
     state: directory
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
@@ -25,7 +25,7 @@
   become_user: '{{ item.username }}'
   template:
     src: settings.json.j2
-    dest: '~{{ item.username }}/.config/Code/User/settings.json'
+    dest: '~{{ item.username }}/{{ vscode_config_path }}/User/settings.json'
     force: no
     mode: 'u=rw,go='
   with_items: '{{ users }}'

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -3,7 +3,7 @@
   become: yes
   become_user: '{{ item.0.username }}'
   file:
-    path: '~{{ item.0.username }}/{{ config_path }}'
+    path: '~{{ item.0.username }}/{{ visual_studio_code_config_path }}'
     state: directory
     mode: 'u=rwx,go=r'
   with_subelements:
@@ -15,7 +15,7 @@
   become: yes
   become_user: '{{ item.username }}'
   file:
-    path: '~{{ item.username }}/{{ vscode_config_path }}/User'
+    path: '~{{ item.username }}/{{ visual_studio_code_config_path }}/User'
     state: directory
     mode: 'u=rwx,go='
   with_items: '{{ users }}'
@@ -25,7 +25,7 @@
   become_user: '{{ item.username }}'
   template:
     src: settings.json.j2
-    dest: '~{{ item.username }}/{{ vscode_config_path }}/User/settings.json'
+    dest: '~{{ item.username }}/{{ visual_studio_code_config_path }}/User/settings.json'
     force: no
     mode: 'u=rw,go='
   with_items: '{{ users }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,7 @@
 ---
 # vars file for visual-studio-code
+config_path: "{{ config_path_mac if ansible_distribution == 'MacOSX' else config_path_linux }}"
+config_path_linux: .config
+config_path_mac: "Library/Application Support"
+
+vscode_config_path: "{{ config_path }}/Code"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,3 @@
 ---
 # vars file for visual-studio-code
-config_path: "{{ config_path_mac if ansible_distribution == 'MacOSX' else config_path_linux }}"
-config_path_linux: .config
-config_path_mac: "Library/Application Support"
-
-vscode_config_path: "{{ config_path }}/Code"
+visual_studio_code_config_path: "{{ 'Library/Application Support' if ansible_distribution == 'MacOSX' else '.config' }}/Code"


### PR DESCRIPTION
I implemented a macOS implementation of the VS Code package. It has some caveats due to the nature of macOS.

Changes to support macOS:
* Add `tasks/install-homebrew.yml` tasks and plumb into `tasks/install.yml`
* Fork the path of where to save `settings.json` based on whether we're running on macOS or Linux

Caveats:
* I'm guessing the molecule VBox setup doesn't support testing on macOS.
* Assumes homebrew is already installed and:
* Either the user has permissions to install home-brew packages (privilege escalation is discouraged by homebrew) or `visual-studio-code` is already installed.

If you want to consume this change, let me know what documentation you need (if any) or additional changes you'd like. Otherwise I'll keep this as a lesser-tested fork and add it to ansible-galaxy as an independent role.