### PR TITLE
Add option update_cache

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -10,6 +10,7 @@
       - libgtk2.0-0
       - libxss1
     state: present
+    update_cache: yes
 
 - name: install key (apt)
   become: yes

--- a/tasks/install-yum.yml
+++ b/tasks/install-yum.yml
@@ -4,6 +4,7 @@
   yum:
     name: which
     state: present
+    update_cache: yes
 
 - name: install VS Code repo (yum)
   become: yes

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -4,6 +4,7 @@
   zypper:
     name: which
     state: present
+    update_cache: yes
 
 - name: install key (zypper)
   become: yes


### PR DESCRIPTION
Add option update_cache for:
- apt
- yum
- zypper

**Note:** dnf supports the tag only in ansible 2.7, so maybe it can be done in future, homebrew has no such option.

**Why do i feel it's needed?**
While running this script in a new system, the script fails and i have to do this manually, hence, i think it might help others as well.

Thanks