### PR TITLE
Fixed Code Insiders config directory name

### DIFF
--- a/molecule/default/tests/test_settings.py
+++ b/molecule/default/tests/test_settings.py
@@ -19,7 +19,7 @@ def test_settings(host):
 
 def test_settings_insiders(host):
     settings_file = host.file(
-        '/home/test_usr/.config/Code-Insiders/User/settings.json')
+        '/home/test_usr/.config/Code - Insiders/User/settings.json')
 
     assert settings_file.exists
     assert settings_file.is_file

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # The name of the directory where the config is stored for this build
-visual_studio_code_config_dirname: "{{ (visual_studio_code_build == 'insiders') | ternary('Code-Insiders', 'Code') }}"
+visual_studio_code_config_dirname: "{{ (visual_studio_code_build == 'insiders') | ternary('Code - Insiders', 'Code') }}"
 
 # Directory under $HOME where where VS Code config is stored
 visual_studio_code_config_path: "{{ (ansible_distribution == 'MacOSX') | ternary('Library/Application Support', '.config') }}/{{ visual_studio_code_config_dirname }}"


### PR DESCRIPTION
Should be `Code - Insiders`.

Bug fix: resolves #156