### PR TITLE
Proxy support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,7 @@ visual_studio_code_download_dir: "{{ x_ansible_download_dir | default(ansible_en
 
 # Users to install extensions for and/or write settings.json
 users: []
+
+# If you want to use some mirror server, then with this you can override the server protocol and URL, e.g. on the command line by using ansible extra-vars.
+# Adding leading directories is possible if needed but no trailing slash should be used.
+packages_microsoft_com: "https://packages.microsoft.com"

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -14,13 +14,13 @@
 - name: install key (apt)
   become: yes
   apt_key:
-    url: 'https://packages.microsoft.com/keys/microsoft.asc'
+    url: '{{packages_microsoft_com}}/keys/microsoft.asc'
     state: present
 
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
-    repo: deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main
+    repo: "deb [arch=amd64] {{packages_microsoft_com}}/repos/vscode stable main"
     filename: vscode
     state: present
 

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -14,13 +14,13 @@
 - name: install key (apt)
   become: yes
   apt_key:
-    url: '{{packages_microsoft_com}}/keys/microsoft.asc'
+    url: '{{ packages_microsoft_com }}/keys/microsoft.asc'
     state: present
 
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
-    repo: "deb [arch=amd64] {{packages_microsoft_com}}/repos/vscode stable main"
+    repo: "deb [arch=amd64] {{ packages_microsoft_com }}/repos/vscode stable main"
     filename: vscode
     state: present
 

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -13,8 +13,8 @@
     name: code
     description: Visual Studio Code repo
     file: vscode
-    baseurl: "{{packages_microsoft_com}}/yumrepos/vscode"
-    gpgkey: "{{packages_microsoft_com}}/keys/microsoft.asc"
+    baseurl: "{{ packages_microsoft_com }}/yumrepos/vscode"
+    gpgkey: "{{ packages_microsoft_com }}/keys/microsoft.asc"
     gpgcheck: yes
 
 - name: install VS Code (dnf)

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -13,8 +13,8 @@
     name: code
     description: Visual Studio Code repo
     file: vscode
-    baseurl: https://packages.microsoft.com/yumrepos/vscode
-    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+    baseurl: "{{packages_microsoft_com}}/yumrepos/vscode"
+    gpgkey: "{{packages_microsoft_com}}/keys/microsoft.asc"
     gpgcheck: yes
 
 - name: install VS Code (dnf)

--- a/tasks/install-yum.yml
+++ b/tasks/install-yum.yml
@@ -11,8 +11,8 @@
     name: code
     description: Visual Studio Code repo
     file: vscode
-    baseurl: https://packages.microsoft.com/yumrepos/vscode
-    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+    baseurl: "{{packages_microsoft_com}}/yumrepos/vscode"
+    gpgkey: "{{packages_microsoft_com}}/keys/microsoft.asc"
     gpgcheck: yes
 
 - name: install VS Code (yum)

--- a/tasks/install-yum.yml
+++ b/tasks/install-yum.yml
@@ -11,8 +11,8 @@
     name: code
     description: Visual Studio Code repo
     file: vscode
-    baseurl: "{{packages_microsoft_com}}/yumrepos/vscode"
-    gpgkey: "{{packages_microsoft_com}}/keys/microsoft.asc"
+    baseurl: "{{ packages_microsoft_com }}/yumrepos/vscode"
+    gpgkey: "{{ packages_microsoft_com }}/keys/microsoft.asc"
     gpgcheck: yes
 
 - name: install VS Code (yum)

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -9,7 +9,7 @@
   become: yes
   rpm_key:
     state: present
-    key: "{{packages_microsoft_com}}/keys/microsoft.asc"
+    key: "{{ packages_microsoft_com }}/keys/microsoft.asc"
 
 - name: write repo configuration (zypper)
   become: yes

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -9,7 +9,7 @@
   become: yes
   rpm_key:
     state: present
-    key: https://packages.microsoft.com/keys/microsoft.asc
+    key: "{{packages_microsoft_com}}/keys/microsoft.asc"
 
 - name: write repo configuration (zypper)
   become: yes

--- a/templates/vscode.repo.j2
+++ b/templates/vscode.repo.j2
@@ -1,8 +1,8 @@
 {{ ansible_managed | comment }}
 [code]
 name=Visual Studio Code
-baseurl=https://packages.microsoft.com/yumrepos/vscode
+baseurl={{packages_microsoft_com}}/yumrepos/vscode
 enabled=1
 type=rpm-md
 gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+gpgkey={{packages_microsoft_com}}/keys/microsoft.asc

--- a/templates/vscode.repo.j2
+++ b/templates/vscode.repo.j2
@@ -1,8 +1,8 @@
 {{ ansible_managed | comment }}
 [code]
 name=Visual Studio Code
-baseurl={{packages_microsoft_com}}/yumrepos/vscode
+baseurl={{ packages_microsoft_com }}/yumrepos/vscode
 enabled=1
 type=rpm-md
 gpgcheck=1
-gpgkey={{packages_microsoft_com}}/keys/microsoft.asc
+gpgkey={{ packages_microsoft_com }}/keys/microsoft.asc


### PR DESCRIPTION
If you want to use some mirror server, then with this you can override the server protocol and URL, e.g. on the command line by using ansible extra-vars.
Adding leading directories is possible if needed but no trailing slash should be used.

The default-key for this feature has that form:
packages_microsoft_com: "https://packages.microsoft.com"
