### PR TITLE
Add ability to force VS Code settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ users:
     visual_studio_code_extensions:
       - # extension 1
       - # extension 2
+    visual_studio_code_settings_force_overwrite: # Force update the settings. Options: "yes" or "no"
     visual_studio_code_settings: # JSON object
 ```
 

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -31,7 +31,7 @@
   template:
     src: settings.json.j2
     dest: '~{{ user.username }}/{{ visual_studio_code_config_path }}/User/settings.json'
-    force: no
+    force: '{{user.visual_studio_code_settings_force_overwrite | default("no")}}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   loop_control:


### PR DESCRIPTION
This change adds the `"visual_studio_code_settings_force_overwrite"` setting property to the user object. By setting it to `"yes"` it will force update the VS Code settings files using the j2 template.

Some users will want to have an idempotent installation.