### PR TITLE
Added ability to overwrite VS Code settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ users:
     visual_studio_code_extensions:
       - # extension 1
       - # extension 2
+    visual_studio_code_settings_force_overwrite: # Force update the settings. Options: "yes" or "no"
     visual_studio_code_settings: # JSON object
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ users:
     visual_studio_code_extensions:
       - # extension 1
       - # extension 2
-    visual_studio_code_settings_force_overwrite: # Force update the settings. Options: "yes" or "no"
+    visual_studio_code_settings_overwrite: # Overwrite the settings file if it exists. Options: boolean "yes" or "no" (defaults to "no").
     visual_studio_code_settings: # JSON object
 ```
 
@@ -85,7 +85,7 @@ Minimal playbook:
     - role: gantsign.visual-studio-code
 ```
 
-Playbook with extensions installed:
+Playbook with extensions installed that overwrites settings:
 
 ```yaml
 - hosts: servers
@@ -97,6 +97,7 @@ Playbook with extensions installed:
             - streetsidesoftware.code-spell-checker
             - wholroyd.jinja
             - ms-python.python
+          visual_studio_code_settings_overwrite: yes
           visual_studio_code_settings: {
             "editor.rulers": [80, 100, 120],
             "editor.renderWhitespace": true,

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -72,7 +72,7 @@
         - username: test_usr3
         - username: test_usr4
           visual_studio_code_settings: {}
-          visual_studio_code_settings_force_overwrite: yes
+          visual_studio_code_settings_overwrite: yes
     - role: ansible-role-visual-studio-code
       visual_studio_code_build: 'insiders'
       users:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,6 +14,7 @@
         - test_usr
         - test_usr2
         - test_usr3
+        - test_usr4
 
     - name: install gnupg2 (apt)
       become: yes
@@ -36,6 +37,21 @@
         state: present
       when: ansible_pkg_mgr == 'apt'
 
+    - name: create settings directory
+      become: yes
+      become_user: test_usr4
+      file:
+        path: /home/test_usr4/.config/Code/User
+        state: directory
+        mode: 'u=rwx,go='
+
+    - name: install default settings
+      become: yes
+      become_user: test_usr4
+      copy:
+        content: '{"remove_me": true}'
+        dest: /home/test_usr4/.config/Code/User/settings.json
+
   roles:
     - role: ansible-role-visual-studio-code
       users:
@@ -54,6 +70,9 @@
           visual_studio_code_extensions: []
           visual_studio_code_settings: {}
         - username: test_usr3
+        - username: test_usr4
+          visual_studio_code_settings: {}
+          visual_studio_code_settings_force_overwrite: yes
     - role: ansible-role-visual-studio-code
       visual_studio_code_build: 'insiders'
       users:

--- a/molecule/default/tests/test_settings.py
+++ b/molecule/default/tests/test_settings.py
@@ -27,3 +27,14 @@ def test_settings_insiders(host):
     assert settings_file.group == 'test_usr'
     assert settings_file.mode == 0o600
     assert settings_file.contains('"Vagrantfile": "ruby"')
+
+
+def test_settings_overwrite(host):
+    settings_file = host.file('/home/test_usr/.config/Code/User/settings.json')
+
+    assert settings_file.exists
+    assert settings_file.is_file
+    assert settings_file.user == 'test_usr'
+    assert settings_file.group == 'test_usr'
+    assert settings_file.mode == 0o600
+    assert not settings_file.contains('remove_me')

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -31,7 +31,7 @@
   template:
     src: settings.json.j2
     dest: '~{{ user.username }}/{{ visual_studio_code_config_path }}/User/settings.json'
-    force: no
+    force: '{{user.visual_studio_code_settings_force_overwrite | default("no")}}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   loop_control:

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -31,7 +31,7 @@
   template:
     src: settings.json.j2
     dest: '~{{ user.username }}/{{ visual_studio_code_config_path }}/User/settings.json'
-    force: '{{ user.visual_studio_code_settings_force_overwrite | default(False) | bool }}'
+    force: '{{ user.visual_studio_code_settings_overwrite | default(False) | bool }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   loop_control:

--- a/tasks/write-settings.yml
+++ b/tasks/write-settings.yml
@@ -31,7 +31,7 @@
   template:
     src: settings.json.j2
     dest: '~{{ user.username }}/{{ visual_studio_code_config_path }}/User/settings.json'
-    force: '{{user.visual_studio_code_settings_force_overwrite | default("no")}}'
+    force: '{{ user.visual_studio_code_settings_force_overwrite | default(False) | bool }}'
     mode: 'u=rw,go='
   with_items: '{{ users }}'
   loop_control:


### PR DESCRIPTION
This change adds the `visual_studio_code_settings_overwrite` property to the user configuration. By setting it to `yes` it will overwrite the VS Code settings file if it exists.