### PR TITLE
added visual_studio_code_userdata_dir / userdatadir

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ Users are configured as follows:
 ```yaml
 users:
   - username: # Unix user name
+    visual_studio_code_userdata_dir: #absolute path to userdatadir (optional)
     visual_studio_code_extensions:
       - # extension 1
       - # extension 2
     visual_studio_code_settings_overwrite: # Overwrite the settings file if it exists. Options: boolean "yes" or "no" (defaults to "no").
     visual_studio_code_settings: # JSON object
+    
 ```
 
 Example Playbooks
@@ -93,6 +95,20 @@ Playbook with extensions installed that overwrites settings:
     - role: gantsign.visual-studio-code
       users:
         - username: vagrant
+          visual_studio_code_extensions:
+            - streetsidesoftware.code-spell-checker
+            - wholroyd.jinja
+            - ms-python.python
+          visual_studio_code_settings_overwrite: yes
+          visual_studio_code_settings: {
+            "editor.rulers": [80, 100, 120],
+            "editor.renderWhitespace": true,
+            "files.associations": {
+              "Vagrantfile": "ruby"
+            }
+          }
+        - ussername: root
+          visual_studio_code_userdata_dir: /root/.vscode
           visual_studio_code_extensions:
             - streetsidesoftware.code-spell-checker
             - wholroyd.jinja

--- a/tasks/install-extensions.yml
+++ b/tasks/install-extensions.yml
@@ -4,6 +4,7 @@
   become_user: '{{ item.0.username }}'
   visual_studio_code_install_extension:
     executable: '{{ visual_studio_code_exe }}'
+    userdatadir: '{{ item.0.visual_studio_code_userdata_dir | default("") }}'
     name: '{{ item.1 }}'
   with_subelements:
     - '{{ users }}'


### PR DESCRIPTION
If you need to install extensions for the root user or you use a different user-data-dir with your installation, you can not use the role right now.
I have added the visual_studio_code_userdata_dir variable inside the user[] variable, so it can be specified. 
I was not sure if i could add anything with sense to the test files, if there are suggestions, that should not be a problem :)

Alex