### PR TITLE
Increased minimum CentOS version to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Requirements
 
         * CentOS
 
-            * 7
+            * 8
 
         * Fedora
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 8
     - name: Ubuntu
       versions:
         - xenial

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-visual-studio-code-centos
-    image: centos:7
+    image: centos:8
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Current VS Code versions require CentOS 8.