### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
         - 8
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Fedora

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-visual-studio-code-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.