### PR TITLE
do not add second repository definition

### DIFF
--- a/molecule/ubuntu-min/converge.yml
+++ b/molecule/ubuntu-min/converge.yml
@@ -1,0 +1,115 @@
+---
+- name: Converge
+  hosts: all
+
+  pre_tasks:
+    - name: create test users
+      become: yes
+      user:
+        name: '{{ item }}'
+        state: present
+        home: '/home/{{ item }}'
+        createhome: yes
+      with_items:
+        - test_usr
+        - test_usr2
+
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install gnupg2 (apt)
+      become: yes
+      apt:
+        name: gnupg2
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install extension cli dependencies (zypper)
+      become: yes
+      zypper:
+        name: libX11-xcb1
+        state: present
+      when: ansible_pkg_mgr == 'zypper'
+
+    - name: install extension cli dependencies (apt)
+      become: yes
+      apt:
+        name: libx11-xcb1
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: create settings directory
+      become: yes
+      become_user: test_usr2
+      file:
+        path: /home/test_usr2/.config/Code/User
+        state: directory
+        mode: 'u=rwx,go='
+
+    - name: install default settings
+      become: yes
+      become_user: test_usr2
+      copy:
+        content: '{"remove_me": true}'
+        dest: /home/test_usr2/.config/Code/User/settings.json
+        mode: 'u=rw,go='
+
+    - name: install microsoft key (apt)
+      become: yes
+      apt_key:
+        url: 'https://packages.microsoft.com/keys/microsoft.asc'
+        state: present
+
+    - name: add /etc/apt/sources.list.d/vscode.list
+      become: yes
+      apt_repository:
+        repo: 'deb [arch=amd64] https://packages.microsoft.com/repos/code stable main'
+        filename: vscode
+        state: present
+
+  roles:
+    - role: ansible-role-visual-studio-code
+      users:
+        - username: test_usr
+          visual_studio_code_extensions:
+            - ms-python.python
+            - wholroyd.jinja
+          visual_studio_code_settings: {
+            "editor.rulers": [80, 100, 120],
+            "editor.renderWhitespace": true,
+            "files.associations": {
+              "Vagrantfile": "ruby"
+            }
+          }
+        - username: test_usr2
+          visual_studio_code_extensions: []
+          visual_studio_code_settings: {}
+          visual_studio_code_settings_overwrite: yes
+    - role: ansible-role-visual-studio-code
+      visual_studio_code_build: 'insiders'
+      users:
+        - username: test_usr
+          visual_studio_code_extensions:
+            - ms-python.python
+            - wholroyd.jinja
+          visual_studio_code_settings: {
+            "editor.rulers": [80, 100, 120],
+            "editor.renderWhitespace": true,
+            "files.associations": {
+              "Vagrantfile": "ruby"
+            }
+          }
+        - username: test_usr2
+          visual_studio_code_extensions: []
+          visual_studio_code_settings: {}
+          visual_studio_code_settings_overwrite: yes
+
+  post_tasks:
+    - name: install which
+      package:
+        name: which
+        state: present
+      when: ansible_pkg_mgr in ('yum', 'dnf', 'zypper')

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -19,7 +19,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    converge: ../default/converge.yml
+    converge: ./converge.yml
   inventory:
     host_vars:
       instance:

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -21,12 +21,27 @@
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
     state: present
 
+- name: check /etc/apt/sources.list.d/vscode.list exists
+  become: yes
+  stat:
+    path: /etc/apt/sources.list.d/vscode.list
+  register: vscode_list_file_stat_result
+
+- name: 'exists url {{ visual_studio_code_mirror }}/repos/code in /etc/apt/sources.list.d/vscode.list'
+  become: yes
+  command: cat /etc/apt/sources.list.d/vscode.list
+  register: cat_vscode_list
+  when: vscode_list_file_stat_result.stat.exists
+  changed_when: not vscode_list_file_stat_result.stat.exists
+
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
     repo: 'deb [arch=amd64] {{ visual_studio_code_mirror }}/repos/code stable main'
     filename: vscode
     state: present
+  when: not cat_vscode_list.stdout is defined or cat_vscode_list.stdout.find('/repos/code') != -1
+  changed_when: cat_vscode_list.stdout is defined and cat_vscode_list.stdout.find('/repos/code') == 0
 
 - name: install VS Code (apt)
   become: yes


### PR DESCRIPTION
Hello @freemanjp ,

sometimes it is needed to provide your own apt repo config. (for example when you behind a company proxy)

therefore I added a check if the end of the URL is already configured in the repo definition.

means:
when the file `/etc/apt/sources.list.d/vscode.list` exists
and it contains already one line with the string `/repos/code`
the task `install VS Code repo (apt)` is skipped