### PR TITLE
Close #203: add flag to skip  task 'install VS Code repo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ visual_studio_code_build: stable
 # with a trailing slash.
 visual_studio_code_mirror: 'https://packages.microsoft.com'
 
+# skip task to add repo for remote package manager
+# if set to true, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
+# if set to false, the repo will be added, this is the default
+visual_studio_code_skip_add_repo: false
+
 # Users to install extensions for and/or write settings.json
 users: []
 ```

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ visual_studio_code_build: stable
 visual_studio_code_mirror: 'https://packages.microsoft.com'
 
 # skip task to add repo for remote package manager
-# if set to true, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
-# if set to false, the repo will be added, this is the default
-visual_studio_code_skip_add_repo: false
+# if set to yes, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
+# if set to no, the repo will be added, this is the default
+visual_studio_code_skip_add_repo: no
 
 # Users to install extensions for and/or write settings.json
 users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,10 @@ visual_studio_code_download_dir: "{{ x_ansible_download_dir | default(ansible_en
 # with a trailing slash.
 visual_studio_code_mirror: 'https://packages.microsoft.com'
 
+# skip task to add repo for remote package manager
+# if set to yes, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
+# if set to no, the repo will be added, this is the default
+visual_studio_code_skip_add_repo: no
+
 # Users to install extensions for and/or write settings.json
 users: []

--- a/molecule/ubuntu-min/converge.yml
+++ b/molecule/ubuntu-min/converge.yml
@@ -1,0 +1,124 @@
+---
+- name: Converge
+  hosts: all
+
+  pre_tasks:
+    - name: create test users
+      become: yes
+      user:
+        name: '{{ item }}'
+        state: present
+        home: '/home/{{ item }}'
+        createhome: yes
+      with_items:
+        - test_usr
+        - test_usr2
+        - test_usr3
+        - test_usr4
+
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install gnupg2 (apt)
+      become: yes
+      apt:
+        name: gnupg2
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install extension cli dependencies (zypper)
+      become: yes
+      zypper:
+        name: libX11-xcb1
+        state: present
+      when: ansible_pkg_mgr == 'zypper'
+
+    - name: install extension cli dependencies (apt)
+      become: yes
+      apt:
+        name: libx11-xcb1
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install key (apt)
+      become: yes
+      apt_key:
+        url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install VS Code repo (apt)
+      become: yes
+      apt_repository:
+        repo: 'deb [arch=amd64] {{ visual_studio_code_mirror }}/repos/code stable main'
+        filename: vscode
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: create settings directory
+      become: yes
+      become_user: test_usr4
+      file:
+        path: /home/test_usr4/.config/Code/User
+        state: directory
+        mode: 'u=rwx,go='
+
+    - name: install default settings
+      become: yes
+      become_user: test_usr4
+      copy:
+        content: '{"remove_me": true}'
+        dest: /home/test_usr4/.config/Code/User/settings.json
+        mode: 'u=rw,go='
+
+  roles:
+    - role: ansible-role-visual-studio-code
+      visual_studio_code_skip_add_repo: yes
+      users:
+        - username: test_usr
+          visual_studio_code_extensions:
+            - ms-python.python
+            - wholroyd.jinja
+          visual_studio_code_settings: {
+            "editor.rulers": [80, 100, 120],
+            "editor.renderWhitespace": true,
+            "files.associations": {
+              "Vagrantfile": "ruby"
+            }
+          }
+        - username: test_usr2
+          visual_studio_code_extensions: []
+          visual_studio_code_settings: {}
+        - username: test_usr3
+        - username: test_usr4
+          visual_studio_code_settings: {}
+          visual_studio_code_settings_overwrite: yes
+    - role: ansible-role-visual-studio-code
+      visual_studio_code_skip_add_repo: yes
+      visual_studio_code_build: 'insiders'
+      users:
+        - username: test_usr
+          visual_studio_code_extensions:
+            - ms-python.python
+            - wholroyd.jinja
+          visual_studio_code_settings: {
+            "editor.rulers": [80, 100, 120],
+            "editor.renderWhitespace": true,
+            "files.associations": {
+              "Vagrantfile": "ruby"
+            }
+          }
+        - username: test_usr2
+          visual_studio_code_extensions: []
+          visual_studio_code_settings: {}
+        - username: test_usr3
+
+  post_tasks:
+    - name: install which
+      package:
+        name: which
+        state: present
+      when: ansible_pkg_mgr in ('yum', 'dnf', 'zypper')

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -19,7 +19,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    converge: ../default/converge.yml
+    converge: ./converge.yml
   inventory:
     host_vars:
       instance:

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -27,6 +27,7 @@
     repo: 'deb [arch=amd64] {{ visual_studio_code_mirror }}/repos/code stable main'
     filename: vscode
     state: present
+  when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (apt)
   become: yes

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -19,6 +19,7 @@
     baseurl: '{{ visual_studio_code_mirror }}/yumrepos/vscode'
     gpgkey: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
     gpgcheck: yes
+  when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (dnf)
   become: yes

--- a/tasks/install-yum.yml
+++ b/tasks/install-yum.yml
@@ -14,6 +14,7 @@
     baseurl: '{{ visual_studio_code_mirror }}/yumrepos/vscode'
     gpgkey: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
     gpgcheck: yes
+  when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (yum)
   become: yes

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -24,6 +24,7 @@
     mode: 'u=rw,go='
     owner: root
     group: root
+  when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (zypper)
   become: yes


### PR DESCRIPTION
introduce a new flag `visual_studio_code_skip_add_repo`

if set to yes, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
if set to no, the repo will be added, this is the default