### PR TITLE
Close #202: new flag visual_studio_code_gpgcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ visual_studio_code_build: stable
 # with a trailing slash.
 visual_studio_code_mirror: 'https://packages.microsoft.com'
 
+# should the gpgcheck of the repo enabled?
+# if yes
+# - for apt repo the option trusted=yes is NOT added
+# - for dnf/yum the option gpgcheck is set to yes
+# - for zypper the option gpgcheck is set to 1
+# yes is the default
+# if no 
+# - for apt repo the option trusted=yes is added to repo definition
+# - for dnf/yum the option gpgcheck is set to no
+# - for zypper the option gpgcheck is set to 0
+visual_studio_code_gpgcheck: yes
+
 # skip task to add repo for remote package manager
 # if set to yes, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
 # if set to no, the repo will be added, this is the default

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,18 @@ visual_studio_code_download_dir: "{{ x_ansible_download_dir | default(ansible_en
 # with a trailing slash.
 visual_studio_code_mirror: 'https://packages.microsoft.com'
 
+# should the gpgcheck of the repo enabled?
+# if yes
+# - for apt repo the option trusted=yes is NOT added
+# - for dnf/yum the option gpgcheck is set to yes
+# - for zypper the option gpgcheck is set to 1
+# yes is the default
+# if no 
+# - for apt repo the option trusted=yes is added to repo definition
+# - for dnf/yum the option gpgcheck is set to no
+# - for zypper the option gpgcheck is set to 0
+visual_studio_code_gpgcheck: yes
+
 # skip task to add repo for remote package manager
 # if set to yes, the task 'install VS Code repo (apt/yum/dnf/zypper)' will be skipped
 # if set to no, the repo will be added, this is the default

--- a/molecule/ubuntu-min-trusted-yes/INSTALL.rst
+++ b/molecule/ubuntu-min-trusted-yes/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/ubuntu-min-trusted-yes/converge.yml
+++ b/molecule/ubuntu-min-trusted-yes/converge.yml
@@ -1,0 +1,35 @@
+---
+- name: Converge
+  hosts: all
+
+  pre_tasks:
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install gnupg2 (apt)
+      become: yes
+      apt:
+        name: gnupg2
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install extension cli dependencies (apt)
+      become: yes
+      apt:
+        name: libx11-xcb1
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+  roles:
+    - role: ansible-role-visual-studio-code
+      visual_studio_code_gpgcheck: no
+
+  post_tasks:
+    - name: install which
+      package:
+        name: which
+        state: present
+      when: ansible_pkg_mgr in ('yum', 'dnf', 'zypper')

--- a/molecule/ubuntu-min-trusted-yes/molecule.yml
+++ b/molecule/ubuntu-min-trusted-yes/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+platforms:
+  - name: ansible-role-visual-studio-code-ubuntu-min-trusted-yes
+    image: ubuntu:18.04
+    dockerfile: ../default/Dockerfile.j2
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+  inventory:
+    host_vars:
+      instance:
+        ansible_user: ansible
+
+verifier:
+  name: testinfra
+  directory: ./tests

--- a/molecule/ubuntu-min-trusted-yes/tests/conftest.py
+++ b/molecule/ubuntu-min-trusted-yes/tests/conftest.py
@@ -1,0 +1,22 @@
+"""PyTest Fixtures."""
+from __future__ import absolute_import
+
+import os
+
+import pytest
+
+
+def pytest_runtest_setup(item):
+    """Run tests only when under molecule with testinfra installed."""
+    try:
+        import testinfra
+    except ImportError:
+        pytest.skip("Test requires testinfra", allow_module_level=True)
+    if "MOLECULE_INVENTORY_FILE" in os.environ:
+        pytest.testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+            os.environ["MOLECULE_INVENTORY_FILE"]
+        ).get_hosts("all")
+    else:
+        pytest.skip(
+            "Test should run only from inside molecule.",
+            allow_module_level=True)

--- a/molecule/ubuntu-min-trusted-yes/tests/test_install.py
+++ b/molecule/ubuntu-min-trusted-yes/tests/test_install.py
@@ -1,0 +1,8 @@
+def test_visual_studio_code(host):
+    assert host.run('which code').rc == 0
+
+
+def test_visual_studio_code_trusted_yes(host):
+    repo_file = host.file('/etc/apt/sources.list.d/vscode.list')
+
+    assert repo_file.contains('trusted=yes')

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -21,20 +21,10 @@
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
     state: present
 
-- name: register empty variable trusted for gpgcheck
-  set_fact:
-    trusted: ''
-  when: visual_studio_code_gpgcheck
-
-- name: register variable trusted=yes for gpgcheck
-  set_fact:
-    trusted: 'trusted=yes'
-  when: not visual_studio_code_gpgcheck
-
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
-    repo: 'deb [arch=amd64 {{ trusted }}] {{ visual_studio_code_mirror }}/repos/code stable main'
+    repo: 'deb [arch=amd64 {{ visual_studio_code_gpgcheck | ternary("", "trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
     filename: vscode
     state: present
   when: not visual_studio_code_skip_add_repo

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -21,10 +21,20 @@
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
     state: present
 
+- name: register empty variable trusted for gpgcheck
+  set_fact:
+    trusted: ''
+  when: visual_studio_code_gpgcheck
+
+- name: register variable trusted=yes for gpgcheck
+  set_fact:
+    trusted: 'trusted=yes'
+  when: not visual_studio_code_gpgcheck
+
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
-    repo: 'deb [arch=amd64] {{ visual_studio_code_mirror }}/repos/code stable main'
+    repo: 'deb [arch=amd64 {{ trusted }}] {{ visual_studio_code_mirror }}/repos/code stable main'
     filename: vscode
     state: present
   when: not visual_studio_code_skip_add_repo

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -18,7 +18,7 @@
     file: vscode
     baseurl: '{{ visual_studio_code_mirror }}/yumrepos/vscode'
     gpgkey: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    gpgcheck: yes
+    gpgcheck: '{{ visual_studio_code_gpgcheck }}'
   when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (dnf)

--- a/tasks/install-yum.yml
+++ b/tasks/install-yum.yml
@@ -13,7 +13,7 @@
     file: vscode
     baseurl: '{{ visual_studio_code_mirror }}/yumrepos/vscode'
     gpgkey: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    gpgcheck: yes
+    gpgcheck: '{{ visual_studio_code_gpgcheck }}'
   when: not visual_studio_code_skip_add_repo
 
 - name: install VS Code (yum)

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -16,16 +16,6 @@
     state: present
     key: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
 
-- name: register variable gpgcheck=1
-  set_fact:
-    gpgcheck_zypper: '1'
-  when: visual_studio_code_gpgcheck
-
-- name: register variable gpgcheck=0
-  set_fact:
-    gpgcheck_zypper: '0'
-  when: not visual_studio_code_gpgcheck
-
 - name: write repo configuration (zypper)
   become: yes
   template:

--- a/tasks/install-zypper.yml
+++ b/tasks/install-zypper.yml
@@ -16,6 +16,16 @@
     state: present
     key: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
 
+- name: register variable gpgcheck=1
+  set_fact:
+    gpgcheck_zypper: '1'
+  when: visual_studio_code_gpgcheck
+
+- name: register variable gpgcheck=0
+  set_fact:
+    gpgcheck_zypper: '0'
+  when: not visual_studio_code_gpgcheck
+
 - name: write repo configuration (zypper)
   become: yes
   template:

--- a/templates/vscode.repo.j2
+++ b/templates/vscode.repo.j2
@@ -4,5 +4,5 @@ name=Visual Studio Code
 baseurl={{ visual_studio_code_mirror }}/yumrepos/vscode
 enabled=1
 type=rpm-md
-gpgcheck={{ gpgcheck_zypper }}
+gpgcheck={{ visual_studio_code_gpgcheck | ternary('1', '0') }}
 gpgkey={{ visual_studio_code_mirror }}/keys/microsoft.asc

--- a/templates/vscode.repo.j2
+++ b/templates/vscode.repo.j2
@@ -4,5 +4,5 @@ name=Visual Studio Code
 baseurl={{ visual_studio_code_mirror }}/yumrepos/vscode
 enabled=1
 type=rpm-md
-gpgcheck=1
+gpgcheck={{ gpgcheck_zypper }}
 gpgkey={{ visual_studio_code_mirror }}/keys/microsoft.asc


### PR DESCRIPTION
when flag `visual_studio_code_gpgcheck` is set to `yes`
- for apt repo the option trusted=yes is NOT added
- for dnf/yum the option gpgcheck is set to yes
- for zypper the option gpgcheck is set to 1
yes is the default

when flag `visual_studio_code_gpgcheck` is set to `no`
- for apt repo the option trusted=yes is added to repo definition
- for dnf/yum the option gpgcheck is set to no
- for zypper the option gpgcheck is set to 0