### PR TITLE
Fixed to match the previous APT repo declaration

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -24,7 +24,7 @@
 - name: install VS Code repo (apt)
   become: yes
   apt_repository:
-    repo: 'deb [arch=amd64 {{ visual_studio_code_gpgcheck | ternary("", "trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
+    repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
     filename: vscode
     state: present
   when: not visual_studio_code_skip_add_repo


### PR DESCRIPTION
This avoids duplicating the APT repo if you'd previously ran an earlier version of the role.