### PR TITLE
Use new way of signing repos to avoid apt-key deprecation warning

### DIFF
--- a/molecule/ubuntu-signed-by/INSTALL.rst
+++ b/molecule/ubuntu-signed-by/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/ubuntu-signed-by/converge.yml
+++ b/molecule/ubuntu-signed-by/converge.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge
+  hosts: all
+
+  pre_tasks:
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: install gnupg2 (apt)
+      become: yes
+      apt:
+        name: gnupg2
+        state: present
+      when: ansible_pkg_mgr == 'apt'
+
+  roles:
+    - role: ansible-role-visual-studio-code
+
+  post_tasks:
+    - name: install which
+      package:
+        name: which
+        state: present
+      when: ansible_pkg_mgr in ('yum', 'dnf', 'zypper')

--- a/molecule/ubuntu-signed-by/molecule.yml
+++ b/molecule/ubuntu-signed-by/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+platforms:
+  - name: ansible-role-visual-studio-code-ubuntu-signed-by
+    image: ubuntu:22.04
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+  inventory:
+    host_vars:
+      instance:
+        ansible_user: ansible
+
+verifier:
+  name: testinfra
+  directory: ./tests

--- a/molecule/ubuntu-signed-by/tests/conftest.py
+++ b/molecule/ubuntu-signed-by/tests/conftest.py
@@ -1,0 +1,22 @@
+"""PyTest Fixtures."""
+from __future__ import absolute_import
+
+import os
+
+import pytest
+
+
+def pytest_runtest_setup(item):
+    """Run tests only when under molecule with testinfra installed."""
+    try:
+        import testinfra
+    except ImportError:
+        pytest.skip("Test requires testinfra", allow_module_level=True)
+    if "MOLECULE_INVENTORY_FILE" in os.environ:
+        pytest.testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+            os.environ["MOLECULE_INVENTORY_FILE"]
+        ).get_hosts("all")
+    else:
+        pytest.skip(
+            "Test should run only from inside molecule.",
+            allow_module_level=True)

--- a/molecule/ubuntu-signed-by/tests/test_install.py
+++ b/molecule/ubuntu-signed-by/tests/test_install.py
@@ -1,0 +1,9 @@
+def test_visual_studio_code(host):
+    assert host.run('which code').rc == 0
+
+
+def test_visual_studio_code_signed_by(host):
+    repo_file = host.file('/etc/apt/sources.list.d/vscode.list')
+
+    assert repo_file.contains(
+        'signed-by=/usr/share/keyrings/packages.microsoft.gpg')

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -60,7 +60,7 @@
     - name: Install VS Code repo (apt)
       become: yes
       ansible.builtin.apt_repository:
-        repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}, signed-by=/usr/share/keyrings/packages.microsoft.gpg] {{ visual_studio_code_mirror }}/repos/code stable main'
+        repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }} signed-by=/usr/share/keyrings/packages.microsoft.gpg] {{ visual_studio_code_mirror }}/repos/code stable main'
         filename: vscode
         state: present
       when: not visual_studio_code_skip_add_repo

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -1,7 +1,7 @@
 ---
-- name: install dependencies (apt)
+- name: Install dependencies (apt)
   become: yes
-  apt:
+  ansible.builtin.apt:
     name:
       - ca-certificates
       - apt-transport-https
@@ -15,22 +15,59 @@
       - libxshmfence1
     state: present
 
-- name: install key (apt)
-  become: yes
-  apt_key:
-    url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    state: present
+- name: Get distribution and codename
+  ansible.builtin.command: lsb_release -{{ item }}
+  register: result
+  with_items: ["is", "rs"]
+  changed_when: No
 
-- name: install VS Code repo (apt)
-  become: yes
-  apt_repository:
-    repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
-    filename: vscode
-    state: present
-  when: not visual_studio_code_skip_add_repo
+- name: Define variables distro and release
+  ansible.builtin.set_fact:
+    distro: "{{ result.results[0].stdout }}"
+    release: "{{ result.results[1].stdout }}"
 
-- name: install VS Code (apt)
+- name: Install key (apt) and VS Code repo (apt)
+  block:
+    - name: Install key (apt)
+      become: yes
+      ansible.builtin.apt_key:
+        url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
+        state: present
+
+    - name: Install VS Code repo (apt)
+      become: yes
+      ansible.builtin.apt_repository:
+        repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
+        filename: vscode
+        state: present
+      when: not visual_studio_code_skip_add_repo
+  when: not ((distro == "Ubuntu" and release | float >= 22.04) or (distro == "Debian" and release | float >= 11))
+
+- name: Install key (gpg) and VS Code repo (apt)
+  block:
+    - name: Install key (gpg)
+      # noqa no-changed-when
+      become: yes
+      ansible.builtin.shell: https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /usr/share/keyrings/packages.microsoft.gpg
+
+    - name: Remove old vscode.list if existing
+      tags: vscode
+      become: yes
+      ansible.builtin.file:
+        state: absent
+        path: /etc/apt/sources.list.d/vscode.list
+
+    - name: Install VS Code repo (apt)
+      become: yes
+      ansible.builtin.apt_repository:
+        repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}, signed-by=/usr/share/keyrings/packages.microsoft.gpg] {{ visual_studio_code_mirror }}/repos/code stable main'
+        filename: vscode
+        state: present
+      when: not visual_studio_code_skip_add_repo
+  when: (distro == "Ubuntu" and release | float >= 22.04) or (distro == "Debian" and release | float >= 11)
+
+- name: Install VS Code (apt)
   become: yes
-  apt:
+  ansible.builtin.apt:
     name: "{{ visual_studio_code_package }}{{ (visual_studio_code_version | length > 0) | ternary('=' + visual_studio_code_version, '') }}"
     state: present


### PR DESCRIPTION
Hi there, hope it is OK to suggest small changes here via PR.
Thanks and best regards,
Juergen

And now to the PR description:

`apt-key` will be last available in Debian 11 and Ubuntu 22.04, see:
https://manpages.ubuntu.com/manpages/jammy/man8/apt-key.8.html
Hence `install-apt.yml` was adapted to use the new way of signing repos
using gpg keys, in case Debian >= 11 or Ubuntu >= 22.04"

(the basic tests are basically copy&pasted from existing tests and slightly adapted)