### PR TITLE
Fixed apt-key deprecation warning

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -15,16 +15,28 @@
       - libxshmfence1
     state: present
 
+- name: Create APT keyrings dir
+  become: yes
+  ansible.builtin.file:
+    path: '/etc/apt/keyrings'
+    state: directory
+    mode: 'u=rwx,go=rx'
+
 - name: Install key (apt)
   become: yes
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    state: present
+    dest: '/etc/apt/keyrings/'
+    mode: 'u=rw,go=r'
+    force: yes
 
 - name: Install VS Code repo (apt)
   become: yes
   ansible.builtin.apt_repository:
-    repo: 'deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}] {{ visual_studio_code_mirror }}/repos/code stable main'
+    repo: >-
+      deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}
+      signed-by=/etc/apt/keyrings/microsoft.asc]
+      {{ visual_studio_code_mirror }}/repos/code stable main
     filename: vscode
     state: present
   when: not visual_studio_code_skip_add_repo


### PR DESCRIPTION
Ubuntu 22.04 will be the last release with `apt-key` (see https://manpages.ubuntu.com/manpages/jammy/man8/apt-key.8.html). `install-apt.yml` was updated to use the new (more secure) way of signing APT repos.

Co-authored-by: @hansmannj (see #221)