### PR TITLE
make apt installation arm package compatible

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -1,4 +1,15 @@
 ---
+vars:
+  deb_architecture: {
+    "armv6l": "armhf",
+    "armv6l": "armhf",
+    "armv7l": "armhf",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+    "x86_64": "amd64",
+    "amd64": "amd64"
+  }
+tasks:
 - name: Install dependencies (apt)
   become: yes
   ansible.builtin.apt:
@@ -30,11 +41,16 @@
     mode: 'u=rw,go=r'
     force: yes
 
+- name: Show detected system architecture \"ansible_architecture\"
+  ansible.builtin.debug:
+    msg: "{{ [ansible_architecture] | map('extract', deb_architecture) | first }}"
+
 - name: Install VS Code repo (apt)
   become: yes
   ansible.builtin.apt_repository:
     repo: >-
-      deb [arch=amd64{{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}
+      deb [arch={{ [ansible_architecture] | map('extract', deb_architecture) | first }}
+      {{ visual_studio_code_gpgcheck | ternary("", " trusted=yes") }}
       signed-by=/etc/apt/keyrings/microsoft.asc]
       {{ visual_studio_code_mirror }}/repos/code stable main
     filename: vscode


### PR DESCRIPTION
fixing #232 

checking the current system architecture and mapping that to the apt binary names (amd64, armhf, arm64) and then only adding the respective repo so vscode role works for all architectures on ubuntu/debian