### PR TITLE
Removing unneeded dependency installation

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -5,14 +5,6 @@
     name:
       - ca-certificates
       - apt-transport-https
-      - gconf2
-      - libasound2
-      - libgtk2.0-0
-      - libxss1
-      - libxcb-dri3-0
-      - libdrm2
-      - libgbm1
-      - libxshmfence1
     state: present
 
 - name: Create APT keyrings dir


### PR DESCRIPTION
This PR closes #243 

Installation of the other dependencies will be handled by apt at the time of installing code. 