### PR TITLE
Updated install_apt Playbook to support apt_key deprication

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -23,12 +23,6 @@
     mode: 'u=rw,go=r'
     force: true
 
-- name: Add key to keyring (apt)
-  become: true
-  ansible.builtin.apt_key:
-    file: '/etc/apt/keyrings/microsoft.asc'
-    state: present
-
 - name: Install VS Code repo (apt)
   become: true
   ansible.builtin.apt_repository:

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -29,7 +29,7 @@
     repo: >-
       deb [arch={{ visual_studio_code_deb_architecture }}
       {{ visual_studio_code_gpgcheck | ternary("", " trusted=true") }}
-      signed-by=/etc/apt/keyrings/microsoft.asc]
+      signed-by=/etc/apt/trusted.gpg.d/microsoft.asc]
       {{ visual_studio_code_mirror }}/repos/code stable main
     filename: vscode
     state: present

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -19,7 +19,7 @@
   become: true
   ansible.builtin.get_url:
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    dest: '/etc/apt/keyrings/'
+    dest: '/etc/apt/trusted.gpg.d/'
     mode: 'u=rw,go=r'
     force: true
 

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -23,6 +23,12 @@
     mode: 'u=rw,go=r'
     force: true
 
+- name: Add key to keyring (apt)
+  become: true
+  ansible.builtin.apt_key:
+    file: '/etc/apt/keyrings/microsoft.asc'
+    state: present
+
 - name: Install VS Code repo (apt)
   become: true
   ansible.builtin.apt_repository:


### PR DESCRIPTION
More info can be found from [Jeff Geerling's](https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible) blog, but downloading a repository key into `/etc/apt/keyrings` no longer works... and causes the `Install VS Code repo (apt)` task to error out.

I modified the `Install key (apt)` task to download the GPG file to `/etc/apt/trusted.gpg.d`, instead of `/etc/apt/keyrings`.

For reference:
- https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible
- https://github.com/ansible/ansible/issues/78063
