### PR TITLE
Fix conflict with apt installation

### DIFF
--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -4,9 +4,7 @@
   become: true
   ansible.builtin.apt:
     name:
-      - ca-certificates
-      - apt-transport-https
-      - gpg
+      - python3-debian
     state: present
 
 - name: Remove old key (apt)
@@ -14,42 +12,6 @@
   ansible.builtin.file:
     path: '/etc/apt/keyrings/microsoft.asc'
     state: absent
-
-- name: Create APT keyrings dir
-  become: true
-  ansible.builtin.file:
-    path: '/usr/share/keyrings/'
-    state: directory
-    mode: 'u=rwx,go=rx'
-
-- name: Download key (apt)
-  become: true
-  ansible.builtin.get_url:
-    url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    dest: '/tmp/'
-    mode: 'u=rw,go=r'
-    force: true
-
-- name: Dearmor key (apt)
-  ansible.builtin.command: gpg --dearmor -o /tmp/microsoft.gpg /tmp/microsoft.asc
-  args:
-    creates: '/tmp/microsoft.gpg'
-
-- name: Install key (apt)
-  become: true
-  ansible.builtin.copy:
-    src: '/tmp/microsoft.gpg'
-    dest: '/usr/share/keyrings/microsoft.gpg'
-    mode: 'u=rw,go=r'
-    force: true
-
-- name: Clean up temporary key files (apt)
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/microsoft.asc
-    - /tmp/microsoft.gpg
 
 - name: Remove old repo (apt)
   become: true
@@ -60,16 +22,15 @@
 
 - name: Install VS Code repo (apt)
   become: true
-  ansible.builtin.copy:
-    content: |
-      Types: deb
-      URIs: {{ visual_studio_code_mirror }}/repos/code
-      Suites: stable
-      Components: main
-      Architectures: {{ visual_studio_code_deb_architecture }}
-      {{ 'Trusted: yes' if not visual_studio_code_gpgcheck else 'Signed-By: /usr/share/keyrings/microsoft.gpg' }}
-    dest: '/etc/apt/sources.list.d/vscode.sources'
-    mode: 'u=rw,go=r'
+  ansible.builtin.deb822_repository:
+    name: vscode
+    types: deb
+    uris: "{{ visual_studio_code_mirror }}/repos/code"
+    suites: stable
+    components: main
+    architectures: "{{ visual_studio_code_deb_architecture }}"
+    signed_by: "{{ visual_studio_code_mirror + '/keys/microsoft.asc' if visual_studio_code_gpgcheck else omit }}"
+    trusted: "{{ true if not visual_studio_code_gpgcheck else omit }}"
   when: not visual_studio_code_skip_add_repo
 
 - name: Install VS Code (apt)
@@ -77,3 +38,4 @@
   ansible.builtin.apt:
     name: "{{ visual_studio_code_package }}{{ (visual_studio_code_version | length > 0) | ternary('=' + visual_studio_code_version, '') }}"
     state: present
+    update_cache: true

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -1,24 +1,34 @@
 # code: language=ansible
 ---
+- name: Remove from old package installation (apt list)
+  become: true
+  vars:
+    old_apt_source_file: '/etc/apt/sources.list.d/vscode.list'
+
+  block:
+    - name: Check if old source file exists
+      ansible.builtin.stat:
+        path: "{{ old_apt_source_file }}"
+      register: old_source_file_stat
+
+    - name: Remove old source file
+      ansible.builtin.file:
+        path: "{{ old_apt_source_file }}"
+        state: absent
+      when: old_source_file_stat.stat.exists
+
+    - name: Remove old apt key file (only if old source file existed)
+      ansible.builtin.file:
+        path: '/etc/apt/keyrings/microsoft.asc'
+        state: absent
+      when: old_source_file_stat.stat.exists
+
 - name: Install dependencies (apt)
   become: true
   ansible.builtin.apt:
     name:
       - python3-debian
     state: present
-
-- name: Remove old key (apt)
-  become: true
-  ansible.builtin.file:
-    path: '/etc/apt/keyrings/microsoft.asc'
-    state: absent
-
-- name: Remove old repo (apt)
-  become: true
-  ansible.builtin.file:
-    path: '/etc/apt/sources.list.d/vscode.list'
-    state: absent
-  when: not visual_studio_code_skip_add_repo
 
 - name: Install VS Code repo (apt)
   become: true

--- a/tasks/install-apt.yml
+++ b/tasks/install-apt.yml
@@ -6,33 +6,70 @@
     name:
       - ca-certificates
       - apt-transport-https
+      - gpg
     state: present
+
+- name: Remove old key (apt)
+  become: true
+  ansible.builtin.file:
+    path: '/etc/apt/keyrings/microsoft.asc'
+    state: absent
 
 - name: Create APT keyrings dir
   become: true
   ansible.builtin.file:
-    path: '/etc/apt/keyrings'
+    path: '/usr/share/keyrings/'
     state: directory
     mode: 'u=rwx,go=rx'
 
-- name: Install key (apt)
+- name: Download key (apt)
   become: true
   ansible.builtin.get_url:
     url: '{{ visual_studio_code_mirror }}/keys/microsoft.asc'
-    dest: '/etc/apt/keyrings/'
+    dest: '/tmp/'
     mode: 'u=rw,go=r'
     force: true
 
+- name: Dearmor key (apt)
+  ansible.builtin.command: gpg --dearmor -o /tmp/microsoft.gpg /tmp/microsoft.asc
+  args:
+    creates: '/tmp/microsoft.gpg'
+
+- name: Install key (apt)
+  become: true
+  ansible.builtin.copy:
+    src: '/tmp/microsoft.gpg'
+    dest: '/usr/share/keyrings/microsoft.gpg'
+    mode: 'u=rw,go=r'
+    force: true
+
+- name: Clean up temporary key files (apt)
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/microsoft.asc
+    - /tmp/microsoft.gpg
+
+- name: Remove old repo (apt)
+  become: true
+  ansible.builtin.file:
+    path: '/etc/apt/sources.list.d/vscode.list'
+    state: absent
+  when: not visual_studio_code_skip_add_repo
+
 - name: Install VS Code repo (apt)
   become: true
-  ansible.builtin.apt_repository:
-    repo: >-
-      deb [arch={{ visual_studio_code_deb_architecture }}
-      {{ visual_studio_code_gpgcheck | ternary("", " trusted=true") }}
-      signed-by=/etc/apt/keyrings/microsoft.asc]
-      {{ visual_studio_code_mirror }}/repos/code stable main
-    filename: vscode
-    state: present
+  ansible.builtin.copy:
+    content: |
+      Types: deb
+      URIs: {{ visual_studio_code_mirror }}/repos/code
+      Suites: stable
+      Components: main
+      Architectures: {{ visual_studio_code_deb_architecture }}
+      {{ 'Trusted: yes' if not visual_studio_code_gpgcheck else 'Signed-By: /usr/share/keyrings/microsoft.gpg' }}
+    dest: '/etc/apt/sources.list.d/vscode.sources'
+    mode: 'u=rw,go=r'
   when: not visual_studio_code_skip_add_repo
 
 - name: Install VS Code (apt)


### PR DESCRIPTION
When vscode is updated via apt upgrade, it automatically creates a new apt source file in /etc/apt/sources.list.d/vscode.sources using the new apt format. This file then used the dearmor key in /usr/share/keyrings which conflict with the armored key specified in the /etc/apt/sources.list.d/vscode.list file that was created by ansible.

To avoid this conflict, I used the new apt format like mentioned in the vscode installation documentation: https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux

Also removed conflicting files.

This should solve #263